### PR TITLE
adjust poem UI in feed page (index.html)

### DIFF
--- a/CSS/base.css
+++ b/CSS/base.css
@@ -47,7 +47,7 @@ nav#navbar {
     cursor: pointer;
     font-size: 14px;
     text-align: center;
-    color: gray;
+    color: var(--second);
 }
 
 @media only screen and (min-width: 700px) {
@@ -101,6 +101,7 @@ nav#navbar {
     align-items: center;
     justify-content: space-between;
     color: var(--erased);
-    border-top: var(--erased) solid 1px;
+    border-bottom: var(--second) solid 1px;
     padding: 5px;
+    margin-bottom: 15px;
 }

--- a/index.html
+++ b/index.html
@@ -25,15 +25,15 @@
             <div class="container">
                 <div class="row" id="poems_show">
                     <article class="poem col-12 col-sm-6 col-sm-4">
+                        <div class="info">
+                          <span class="author"> </span>
+                          <span class="lastupdate"> </span>
+                        </div>
                         <div class="body">
                             <span class="title"> </span>
                             <textarea spellcheck="false" class="text" oninput='this.style.height = "";this.style.height = this.scrollHeight + "px"'>
         
                             </textarea>
-                        </div>
-                        <div class="info">
-                            <span class="author"> </span>
-                            <span class="lastupdate"> </span>
                         </div>
                     </article>
                 </div>

--- a/js/poems.js
+++ b/js/poems.js
@@ -204,17 +204,18 @@ function showPoems(component_id,poems){
     poems.forEach((p,i)=>{
         result += `
         <article class="poem col-12 col-sm-6 col-md-4">
+            <div class="info">
+                <span class="author">${p.author}</span>
+                <span class="lastupdate">${p.lastupdate.toDateString()}</span>
+                <div class="edit-btn" id="edit-btn-${i}" onclick="editPoem(${i})">Editar</div>
+            </div>
+            
             <div class="body">
                 <span class="title">${p.title}</span>
                 <textarea id="poem_${i}" spellcheck="false" class="text poem-textarea" disabled>
                     ${p.content}
                 </textarea>
             </div>
-            <div class="info">
-                <span class="author">${p.author}</span>
-                <span class="lastupdate">${p.lastupdate.toDateString()}</span>
-            </div>
-            <div class="edit-btn" id="edit-btn-${i}" onclick="editPoem(${i})">Editar</div>
         </article>
         `;
     });


### PR DESCRIPTION
The info and edit part of the poem card is now rendered on the top part of the "card". This way, it doesn't matter the size of the poem, those pieces will always be rendered in the same place.

Fix #39 